### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Genealogy-MCP/gramps-mcp/security/code-scanning/2](https://github.com/Genealogy-MCP/gramps-mcp/security/code-scanning/2)

To fix the problem, explicitly define a `permissions` block that grants only the minimal required access for this CI workflow. Since the jobs only read the code and dependencies and do not write back to the repo or interact with issues/PRs, `contents: read` is sufficient. This can be done once at the top workflow level so it applies to all jobs by default.

The best fix without changing existing functionality is to add a top-level `permissions:` section after `name: CI` (or just before `jobs:`) with `contents: read`. This way, all three jobs (`lint`, `test`, and `security`) inherit these minimal token permissions, and no other changes to steps or job definitions are necessary. No imports or additional methods are required because this is a YAML configuration change only.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

at the root level, aligned with `name:` and `on:`. No per-job `permissions` blocks are required unless future changes need broader scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
