### PR TITLE
fix: increase report fetch retry tolerance for CI

### DIFF
--- a/src/gramps_mcp/tools/analysis.py
+++ b/src/gramps_mcp/tools/analysis.py
@@ -178,8 +178,9 @@ async def _fetch_report_with_retry(
     tree_id: str,
     report_id: str,
     filename: str,
-    max_retries: int = 3,
-    initial_delay: float = 0.5,
+    max_retries: int = 5,
+    initial_delay: float = 1.0,
+    max_delay: float = 5.0,
 ) -> str:
     """
     Download a processed report file, retrying on 404.
@@ -195,6 +196,7 @@ async def _fetch_report_with_retry(
         filename: Generated report filename from task result.
         max_retries: Maximum number of retry attempts on 404.
         initial_delay: Seconds to wait before first retry (doubles each time).
+        max_delay: Upper bound on backoff delay in seconds.
 
     Returns:
         Report content as a string (HTML).
@@ -228,7 +230,7 @@ async def _fetch_report_with_retry(
                 f"{1 + max_retries}), retrying in {delay}s..."
             )
             await asyncio.sleep(delay)
-            delay *= 2
+            delay = min(delay * 2, max_delay)
 
     raise AssertionError("Unreachable: loop always returns or raises")
 

--- a/tests/test_analysis_unit.py
+++ b/tests/test_analysis_unit.py
@@ -5,6 +5,7 @@ tree stats, report tools, and report download retry logic.
 Tests mock GrampsWebAPIClient to avoid network calls.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -722,3 +723,41 @@ class TestFetchReportWithRetry:
                 initial_delay=0.01,
             )
         assert client.make_api_call.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_max_delay_caps_backoff(self):
+        """Backoff delay never exceeds max_delay."""
+        client = AsyncMock()
+        # 4 consecutive 404s then success on attempt 5
+        client.make_api_call = AsyncMock(
+            side_effect=[
+                GrampsAPIError("404 not found"),
+                GrampsAPIError("404 not found"),
+                GrampsAPIError("404 not found"),
+                GrampsAPIError("404 not found"),
+                {"raw_content": "<h1>OK</h1>"},
+            ]
+        )
+
+        sleep_values: list[float] = []
+        original_sleep = asyncio.sleep
+
+        async def _capture_sleep(seconds: float) -> None:
+            sleep_values.append(seconds)
+            await original_sleep(0)  # yield without real delay
+
+        with patch("src.gramps_mcp.tools.analysis.asyncio.sleep", _capture_sleep):
+            result = await _fetch_report_with_retry(
+                client,
+                "tree1",
+                "descend_report",
+                "output.html",
+                max_retries=5,
+                initial_delay=2.0,
+                max_delay=3.0,
+            )
+
+        assert result == "<h1>OK</h1>"
+        assert client.make_api_call.call_count == 5
+        # Delays: 2.0, 3.0, 3.0, 3.0 (capped at max_delay=3.0)
+        assert sleep_values == [2.0, 3.0, 3.0, 3.0]


### PR DESCRIPTION
## Summary

- Increases `_fetch_report_with_retry` defaults from `max_retries=3, initial_delay=0.5s` to `max_retries=5, initial_delay=1.0s`
- Adds `max_delay=5.0s` parameter to cap exponential backoff
- Worst-case wait increases from ~3.5s to ~17s, sufficient for slow CI runners

## Context

PR #9 (Dependabot: bump Docker base image) has a flaky `test (py3.11)` failure in `test_get_descendants_real_api` / `test_get_ancestors_real_api`. The root cause is a race condition: Celery marks the report task as SUCCESS before the processed file is available via the web endpoint. The previous retry budget was too small for slower CI runners.

## Test plan

- [x] New unit test `test_max_delay_caps_backoff` validates the `max_delay` cap
- [x] All 442 unit tests pass (`make test-unit`)
- [x] Lint, format, and type checks pass
- [ ] CI pipeline passes all 4 Python versions
- [ ] After merge, rebase PR #9 to verify the fix resolves the flake