### PR TITLE
fix: improve MCP tool discoverability for LLM clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `summarize_params()` in `operations.py` now surfaces enum member values in type strings,
+  so `search` results show `EntityType: person, family, event, ...` instead of just
+  `EntityType` — eliminates LLM guesswork about valid values
+- `get` operation summary and description now explicitly state "There are no per-type get
+  operations" to prevent LLMs from inventing names like `get_person`, `get_citation`
+- `SimpleGetParams.type` description corrected from "person or family" to the full list of
+  9 valid entity types
+- `search` tool description now warns that `query` is a top-level parameter (not inside
+  `params`) — fixes shape-copying mistake where LLMs mirror `execute`'s call structure
+- `execute` tool description now warns against per-entity operation names and shows the
+  expected `{operation: '...', params: {...}}` call shape
+
 ## [2.1.0] - 2026-03-20
 
 ### Added

--- a/src/gramps_mcp/models/parameters/simple_params.py
+++ b/src/gramps_mcp/models/parameters/simple_params.py
@@ -72,7 +72,12 @@ class SimpleSearchParams(BaseModel):
 class SimpleGetParams(BaseModel):
     """Simplified parameters for getting entity details."""
 
-    type: EntityType = Field(description="Entity type (person or family)")
+    type: EntityType = Field(
+        description=(
+            "Entity type: person, family, event, place, source, "
+            "citation, media, repository, note"
+        )
+    )
     handle: Optional[str] = Field(default=None, description="Entity handle")
     gramps_id: Optional[str] = Field(
         default=None, description="Gramps ID (e.g., I0001 or F0001)"

--- a/src/gramps_mcp/operations.py
+++ b/src/gramps_mcp/operations.py
@@ -24,6 +24,7 @@ behavioral hints. The ``search`` meta-tool queries this registry; the
 """
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Callable, Optional
 
 from pydantic import BaseModel, Field
@@ -180,8 +181,16 @@ OPERATION_REGISTRY: dict[str, OperationEntry] = {
     # --- read (3) ---
     "get": OperationEntry(
         name="get",
-        summary="Get full details for any entity by handle or gramps_id",
-        description="Get full details for any entity by handle or gramps_id",
+        summary=(
+            "Get full details for any entity (person, family, event, place, "
+            "source, citation, media, repository, note) by handle or gramps_id. "
+            "There are no per-type get operations."
+        ),
+        description=(
+            "Get full details for any entity (person, family, event, place, "
+            "source, citation, media, repository, note) by handle or gramps_id. "
+            "There are no per-type get operations."
+        ),
         category="read",
         params_schema=SimpleGetParams,
         handler=get_tool,
@@ -460,6 +469,9 @@ def summarize_params(schema: type) -> list[dict[str, Any]]:
     for name, field_info in schema.model_fields.items():
         annotation = field_info.annotation
         type_str = getattr(annotation, "__name__", str(annotation))
+        if isinstance(annotation, type) and issubclass(annotation, Enum):
+            values = [e.value for e in annotation]
+            type_str = f"{type_str}: {', '.join(values)}"
         result.append(
             {
                 "name": name,

--- a/src/gramps_mcp/server.py
+++ b/src/gramps_mcp/server.py
@@ -71,8 +71,10 @@ _META_TOOLS = {
         "handler": search_operations_tool,
         "description": (
             "Discover available operations and their parameters. "
+            "Call with a top-level 'query' string (not inside params). "
             "Returns matching operations with parameter schemas. "
-            "Use this before calling 'execute' to find the right operation."
+            "Always use this before calling 'execute' to find the correct "
+            "operation name."
         ),
         "annotations": ToolAnnotations(
             readOnlyHint=True,
@@ -86,8 +88,10 @@ _META_TOOLS = {
         "handler": execute_operation_tool,
         "description": (
             "Run a named operation against the Gramps Web API. "
-            "Use 'search' first to discover operations and parameters, "
-            "then call this with the operation name and params dict."
+            "Operations use generic names (e.g. 'get', not 'get_person'). "
+            "Use 'search' first to discover the exact operation name and its "
+            "params schema, then call this with "
+            "{operation: '...', params: {...}}."
         ),
         "annotations": ToolAnnotations(
             readOnlyHint=False,


### PR DESCRIPTION
## Summary

- LLM clients were consistently misusing the two meta-tools in three ways: inventing per-entity operation names (`get_person`, `get_citation`), nesting `query` inside `params` when calling `search`, and being unable to determine valid enum values for parameters like `EntityType`
- `summarize_params()` now appends enum member values to the type string so `search` results show `EntityType: person, family, event, ...` instead of just the opaque class name
- `SimpleGetParams.type` description was wrong ("person or family") — corrected to list all 9 valid entity types
- `get` operation description now explicitly states "There are no per-type get operations" to prevent invented names
- `search` and `execute` tool descriptions updated with targeted warnings against known LLM mistake patterns

## Changes

**`src/gramps_mcp/operations.py`**
- Added `from enum import Enum` import
- `summarize_params()`: when annotation is an Enum subclass, append `': value1, value2, ...'` to the type string
- `get` operation: expanded summary/description to list all entity types and state no per-type operations exist

**`src/gramps_mcp/models/parameters/simple_params.py`**
- `SimpleGetParams.type` field description: "person or family" → full list of 9 types

**`src/gramps_mcp/server.py`**
- `search` description: added "Call with a top-level 'query' string (not inside params)"
- `execute` description: added "Operations use generic names (e.g. 'get', not 'get_person')" and explicit call shape

## Test plan

- `make lint && make typecheck` — passes (ruff + pyright zero errors)
- `make test-unit` — 532 passed, 90.08% branch coverage
- Manual: call `execute(operation="search", params={"query": "get"})` and verify the `type` parameter now shows `EntityType: person, family, event, place, source, citation, media, repository, note` in the output