### PR TITLE
feat: support partial updates on upsert operations and improve error recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-03-20
+
+### Fixed
+- `upsert_media` now gracefully handles 409 Conflict when replacing a media file with
+  identical content (same checksum). The duplicate upload is skipped and the metadata-only
+  update proceeds normally. Previously this caused a hard failure.
+
 ### Changed
 - `summarize_params()` in `operations.py` now surfaces enum member values in type strings,
   so `search` results show `EntityType: person, family, event, ...` instead of just
@@ -41,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 4 prefix suggestion tests in `test_meta_tools.py`: verify `get_media`, `search_person`,
   `delete_event` all surface the correct generic operation name in the error message
 - `test_get_description_mentions_type_parameter` in `test_search_unit.py`
+- 2 unit tests for 409 Conflict handling in `test_data_management_unit.py`:
+  `test_update_media_409_skips_upload` and `test_update_media_non_409_error_propagates`
 
 ## [2.1.0] - 2026-03-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gramps-mcp"
-version = "2.1.0"
+version = "2.1.1"
 description = "AI-Powered Genealogy Research & Management - MCP server for Gramps Web API"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

- **Partial updates on all 8 upsert models**: converted create-required fields (desc, primary_name, type, etc.) from field-level required to optional with conditional validation via `@model_validator`. Allows updates to proceed when only some fields are provided, with existing values merged by the API.
- **Improved operation name discoverability**: added prefix-based suggestions to catch LLM-generated per-type names (`get_media`, `search_person`) and suggest the correct generic operation (`get`, `search`).
- **Graceful 409 Conflict handling**: `upsert_media` now catches 409 responses on file re-upload (same checksum), logs as warning, and proceeds with metadata-only update instead of failing the entire operation.
- **Release v2.1.1**: version bump with full test coverage for all three fixes.

## Changes

### Pydantic Models (all 8 upsert)
- `MediaSaveParams.desc`, `PersonData.primary_name/gender`, `EventSaveParams.type/citation_list`, `PlaceSaveParams.place_type`, `SourceSaveParams.title`, `CitationData.source_handle`, `NoteSaveParams.text/type`, `RepositoryData.name/type` — changed from field-level required to `Optional[T] = Field(None, ...)` with `@model_validator(mode="after")` enforcing presence only when `handle is None` (create mode).

### Operation Discovery
- `meta_execute.py`: added prefix matching after difflib fuzzy search to catch per-type operation names and surface correct generic operation.
- `operations.py`: updated summaries for `get`, `search`, `delete` with explicit "Do NOT use per-type names" warnings.

### Media Upload
- `data_management_media.py`: wrapped file replacement in try-except to catch 409 Conflict (file already exists with same checksum), log as warning, and continue with metadata-only PUT.

### Tests
- `TestUpsertPartialUpdate` (10 tests): verify all 8 upsert models accept partial updates and enforce create-required on create.
- `TestExecuteOperationTool` (4 new tests): verify prefix-based suggestions for `get_media`, `search_person`, `delete_event`.
- `test_update_media_409_skips_upload` / `test_update_media_non_409_error_propagates`: verify 409 handling.
- `test_parameter_alignment.py`: updated 8 alignment tests to check `create_required` vs field-level required.

## Test plan

- `make test-unit` — 568 unit tests pass (89.89% branch coverage).
- Manual verification (if applicable):
  1. Update media with unchanged file → expect 409 warning logged, metadata update proceeds.
  2. Call `execute` with `operation="get_media"` → expect error message suggests `"get"`.
  3. Create upsert call without required fields (handle=None) → expect validation error.
  4. Update upsert call without optional fields (handle present) → expect API call to merge with existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)